### PR TITLE
add support for socket perms

### DIFF
--- a/t/007_socket_perm.t
+++ b/t/007_socket_perm.t
@@ -1,0 +1,36 @@
+#!perl
+use warnings;
+use strict;
+use Test::More;
+use CGI::Fast;
+
+{ no warnings 'redefine'; sub FCGI::Accept ($) {} }
+
+my $f = 'fcgi.sock';
+
+import CGI::Fast socket_path => $f;
+ok( !-e $f, 'socket not exists' );
+CGI::Fast->new();
+ok( -e $f, 'socket was created' );
+is( 0777 & (stat $f)[2], 0777 & ~umask, 'socket has default perms' );
+unlink $f;
+undef $CGI::Fast::Ext_Request;
+
+import CGI::Fast socket_perm => 0777;
+ok( !-e $f, 'socket not exists' );
+CGI::Fast->new();
+ok( -e $f, 'socket was created' );
+is( 0777 & (stat $f)[2], 0777, 'socket has given perms' );
+unlink $f;
+undef $CGI::Fast::Ext_Request;
+
+import CGI::Fast socket_perm => 0777;
+ok( !-e $f, 'socket not exists' );
+$ENV{FCGI_SOCKET_PERM} = 0666;
+CGI::Fast->new();
+ok( -e $f, 'socket was created' );
+is( 0777 & (stat $f)[2], 0666, '$FCGI_SOCKET_PERM has higher priority' );
+unlink $f;
+undef $CGI::Fast::Ext_Request;
+
+done_testing();


### PR DESCRIPTION
Implements #8 

- We probably should use croak instead of die, but this will need to 'use Carp' and you target at so old perl so I'm not sure is it ok to use it.
- You may need to SKIP t/007_socket_perm.t on Win32 (I don't think it has UNIX Domain sockets).
- It probably better to use File::Temp to generate socket name instead of using hardcoded 'fcgi.sock' and create it at module's root directory while testing, but, again, I wasn't sure is it ok to add extra dependency.

P.S. Looks like you should run `make manifest` - several files are missing.