### PR TITLE
Make sure to use Carp before, er, using it

### DIFF
--- a/lib/CGI/Fast.pm
+++ b/lib/CGI/Fast.pm
@@ -6,6 +6,7 @@ use if $] >= 5.019, 'deprecate';
 $CGI::Fast::VERSION='2.10';
 
 use CGI;
+use CGI::Carp;
 use FCGI;
 # use vars works like "our", but is compatible with older Perls.
 use vars qw(


### PR DESCRIPTION
Before:
```
$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
$ perl -Ilib -MCGI::Fast=socket_path,'/tmp/asdf',socket_perm,9876 -e 'CGI::Fast->new'
Undefined subroutine &CGI::Fast::croak called at lib/CGI/Fast.pm line 55.
```
After:
```
$ git checkout bugfix/use_cgi_carp
Switched to branch 'bugfix/use_cgi_carp'
$ perl -Ilib -MCGI::Fast=socket_path,'/tmp/asdf',socket_perm,9876 -e 'CGI::Fast->new'
[Thu Nov 17 19:03:35 2016] -e: Couldn't chmod(/tmp/asdf): Inappropriate file type or format at lib/CGI/Fast.pm line 55.
```